### PR TITLE
Update guides to include Origami patterns.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,39 +3,39 @@
 
 There are several ways to contribute to this proposal process:
 
-  - [Discuss existing component proposals which are under consideration](#discuss-existing-proposals)
-  - [Propose a new component](#propose-a-new-component)
+  - [Discuss existing proposals which are under consideration](#discuss-existing-proposals)
+  - [Propose a new component or pattern](#propose-a-new-component-or-pattern)
   - [Review a proposal](#review-a-proposal) (Origami team only)
 
 
 ## Discuss Existing Proposals
 
-You should feel free to discuss any existing component proposals which are in the [proposal backlog], and are in the "Proposed" or "Under Consideration" columns. Some examples of useful contributions to the discussion:
+You should feel free to discuss any existing proposals which are in the [proposal backlog], and are in the "Proposed" or "Under Consideration" columns. Some examples of useful contributions to the discussion:
 
-  - Asking questions about a component proposal
+  - Asking questions about a proposal
   - Answering questions from other contributors
+  - Sharing research relating to the proposal
   - Sharing examples or demos of a component or pattern that's similar
-  - Sharing research relating to the proposed component
   - Sharing additional use-cases or variants which would be useful to you
 
-Once a component has been accepted and built, you should initate discussion in the repository for that component rather than here.
+If the proposal is for a new component, which has been accepted and built, you should initate discussion in the repository for that component rather than here.
 
 
-## Propose a New Component
+## Propose a New Component or Pattern
 
-Anybody can propose a new component for inclusion in Origami. This can be a completely new component or an existing one which would benefit from being maintained by the Origami team. We ask that you complete the steps below:
+Anybody can propose a new component or pattern for inclusion in Origami. This can be a completely new component, an existing component which would benefit from being maintained by the Origami team, or a pattern that would impact multiple components. We ask that you complete the steps below:
 
   1. ### Check the Registry
 
-     Before proposing a new component, please check and search the [Origami Registry] so that you're sure we haven't already built a similar component. If you find something and need changes made to it, then please open an issue on the component repository.
+     If proposing a new component, please check and search the [Origami Registry] so that you're sure we haven't already built a similar component. If you find something and need changes made to it, then please open an issue on the component repository.
 
   2. ### Check the Backlog
 
-     Before proposing a new component, please check and search the [proposal backlog] for similar issues. If there is already a proposal that's similar to yours then you can comment on the issue and share examples or evidence that you have to support this proposal.
+     Before proposing a new component or pattern, please check and search the [proposal backlog] for similar issues. If there is already a proposal that's similar to yours then you can comment on the issue and share examples or evidence that you have to support this proposal.
 
   3. ### Raise an Issue
 
-     If your component idea is not already proposed in the backlog, please [raise an issue] on this repository and follow the provided template. The more detail you include the better. We prefer you to open an issue yourself, but if you don't have a GitHub account then you can also [email a proposal to the team](mailto:origami.support@ft.com?subject=Component%20Proposal). If you're doing this then please [follow the issue template][issue template].
+     If your idea is not already proposed in the backlog, please [raise an issue] on this repository and follow the provided template. The more detail you include the better. We prefer you to open an issue yourself, but if you don't have a GitHub account then you can also [email a proposal to the team](mailto:origami.support@ft.com?subject=Component%20Proposal). If you're doing this then please [follow the issue template][issue template].
 
   4. ### Request Feedback
 
@@ -44,23 +44,23 @@ Anybody can propose a new component for inclusion in Origami. This can be a comp
 
 ## Review a Proposal
 
-This section is for members of the Origami team, and acts as a guide for reviewing and accepting (or not accepting) component proposals. It's publicly visible here to make our component proposal process as transparent as possible.
+This section is for members of the Origami team, and acts as a guide for reviewing and accepting (or not accepting) proposals. It's publicly visible here to make our component proposal process as transparent as possible.
 
   1. ### Mark as Under Consideration
 
-     Once a component has been proposed, we move it to the "Under Consideration" column in order to indicate that we've seen and are considering the proposal.
+     Once a component or pattern has been proposed, we move it to the "Under Consideration" column in order to indicate that we've seen and are considering the proposal.
 
   2. ### Questions
 
-     During the proposal it's good to ask questions which help solidify the scope of the component. E.g. if there are multiple variants then ask why, if any behaviour is unclear then ask for clarity, and if the component is only used in one place we should question why it needs to be maintained by Origami.
+     During the proposal process it's good to ask questions which help solidify the scope of the proposal. E.g. if there are multiple variants of a new component then ask why, if any behaviour is unclear then ask for clarity, and if the component is only used in one place we should question why it needs to be maintained by Origami.
 
      It's useful to have _some_ design thinking up front. If there's not then it'd be good to also involve the design team at this stage.
 
   3. ### Acceptance
 
-     If, after discussing the component, it's decided that Origami should take on the work then we should outline our reasoning in a comment on the issue. Then we move it to the "Accepted" column and add the appropriate labels.
+     If, after discussing the proposal, it's decided that Origami should take on the work then we should outline our reasoning in a comment on the issue. Then we move it to the "Accepted" column and add the appropriate labels.
 
-	 If the component is not going to be accepted then we should also provide some reasoning and move to the "Not Accepted" column. It's important to also note that if somebody in future has a need for the same component then we can reopen the proposal and accept further evidence and reasoning.
+	  If the proposal is not going to be accepted then we should also provide some reasoning and move to the "Not Accepted" column. It's important to also note that if somebody in future has a need for the same proposal then we can reopen the proposal and accept further evidence and reasoning.
 
 
 [issue template]: https://github.com/Financial-Times/origami-proposals/blob/master/.github/ISSUE_TEMPLATE.md

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,6 @@
 
 <!--
-Please ensure that you have checked both the Origami Registry
-and the Component Backlog for similar components before opening
-a new proposal:
+If proposing a new Origami component, please ensure that you have checked both the Origami Registry and the Component Backlog for similar components:
 
 Registry: https://registry.origami.ft.com/
 Backlog: https://github.com/Financial-Times/origami-proposals/projects/1
@@ -15,15 +13,23 @@ contact the Origami team at origami.support@ft.com or
 
 ## What
 
-> Give a brief description of the component you wish to propose. This should be a short pitch so that we can quickly spot duplicated. It's helpful in this section to also suggest alternative names, e.g. a loading indicator could also be known as a "spinner"
+> Give a brief description of the component or pattern you wish to propose. This should be a short pitch so that we can quickly spot duplicate components, or previously proposed patterns.
+> If proposing a new component, it's helpful in this section to also suggest alternative names, e.g. a loading indicator could also be known as a "spinner".
 
 
 ## Why
 
-> Explain why you think this should be added to Origami or maintained by the Origami team.
+> Explain why you think Origami should accept the proposal.
 >
+> E.g. When proposing a new component:
 > - What evidence do you have that it's needed by multiple teams across the FT?
 > - What evidence do you have that it meets the needs of the users of those teams?
+>
+> E.g. When proposing a pattern:
+> - What problem does the proposal aim to address?
+> - Are there any known caveats to the proposal?
+> - Which components, if any, would be affected by the proposal if it were accepted?
+> - How would the proposal, if accepted, impact your workflow or that of other Origami users?
 
 
 ## Supporting Examples

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 
 # Origami Proposals
 
-This repository is used to propose and track new [Origami] components.<br/>
+This repository is used to propose and track new [Origami] components, or patterns which impact multiple components.<br/>
 For more information, please view the [Contributing Guide].
 
 
 ## Proposal Backlog
 
-The **[Proposal Backlog]** is where you can track and edit new Origami components. We recommend checking here first before proposing a new component.
+The **[Proposal Backlog]** is where you can track and edit proposals. We recommend checking here first before proposing a new component.
 
 
 ## Propose a new Component
 
-The **[Contributing Guide]** outlines how to propose a new component.
+The **[Contributing Guide]** outlines how to create a new proposal, including how to propose a new component.
 
 
 ## Credit


### PR DESCRIPTION
Proposals may not always be a new component. They may also be broader Origami patterns.
- [Primary Mixin](https://github.com/Financial-Times/origami-proposals/issues/6) (current proposal)
- [Remove the ability to customise classes across components](https://github.com/Financial-Times/origami-proposals/issues/4) (accepted proposal)

This PR updates the guides accordingly.